### PR TITLE
feat: new settings tests

### DIFF
--- a/src/e2e/index.ts
+++ b/src/e2e/index.ts
@@ -3,6 +3,11 @@
 /**
  * @file Orchestration for our Quench tests
  */
+// SETTINGS TESTING IMPORT
+import settingsTests, {
+  key as settingsKey,
+  options as settingsOptions,
+} from "../module/__tests__/settings.test";
 // ACTOR TESTING IMPORTS
 import actorDataModelCharacterTests, {
   key as actorDataModelCharacterKey,
@@ -150,6 +155,14 @@ type Quench = {
 };
 
 Hooks.on("quenchReady", async (quench: Quench) => {
+  /* ------------------------------------------- */
+  /* SETTINGS TESTING                            */
+  /* ------------------------------------------- */
+  quench.registerBatch(
+    settingsKey,
+    settingsTests,
+    settingsOptions
+  );
   /* ------------------------------------------- */
   /* ACTOR TESTING                               */
   /* ------------------------------------------- */

--- a/src/module/__tests__/settings.test.ts
+++ b/src/module/__tests__/settings.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @file Contains tests for settings
+ */
+// eslint-disable-next-line prettier/prettier, import/no-cycle
+import { QuenchMethods } from "../../e2e";
+import OSE from "../config";
+
+export const key = "ose.settings";
+export const options = {
+  displayName: "OSE: Settings",
+};
+
+export default ({ describe, it, expect }: QuenchMethods) => {
+  describe("Settings", () => {
+
+    describe("applyDamageOption", () => {
+
+
+      it("Settings menu is populated", async () => {
+            expect(game.settings.settings.get(game.system.id+ ".applyDamageOption")?.choices).contains({selected:"OSE.Setting.damageSelected"});
+            expect(game.settings.settings.get(game.system.id+ ".applyDamageOption")?.choices).contains({targeted:"OSE.Setting.damageTarget"});
+            expect(game.settings.settings.get(game.system.id+ ".applyDamageOption")?.choices).contains({originalTarget:"OSE.Setting.damageOriginalTarget"});
+      });
+    });
+  });
+};


### PR DESCRIPTION
This is in response to a casually slipped-in error that caused one of our settings not to validate to the correct values in OSE 1.8.0

I don't think I have the right approach here, but I couldn't figure out how to cycle through Config.OSE.apply_damage_options and check each key-value against the setting's choices. Suggestions encouraged!

I'll get to the other settings after that